### PR TITLE
Fix bugs about bignumber

### DIFF
--- a/src/oraclize.test.ts
+++ b/src/oraclize.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable functional/prefer-readonly-type */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import test from 'ava'
-import { BigNumber } from 'ethers'
+import { bignumber, BigNumber } from 'mathjs'
 import sinon from 'sinon'
 import { oraclize } from './oraclize'
 import * as providerModules from './common'
@@ -17,24 +17,29 @@ let isUpdateCap: sinon.SinonStub<
 	Promise<boolean>
 >
 
+const dummyNumber =
+	'3175573141986827732.939958658618868394957633106846215492361'
+
 test.before(() => {
 	getProvider = sinon.stub(providerModules, 'getProvider')
 	getProvider.withArgs('mainnet').returns({ network: 'mainnet' } as any)
 
 	getCap = sinon.stub(capModules, 'getCap')
-	getCap.withArgs({ network: 'mainnet' } as any).resolves(BigNumber.from(100))
+	getCap
+		.withArgs({ network: 'mainnet' } as any)
+		.resolves(bignumber(dummyNumber))
 	isUpdateCap = sinon.stub(checkModules, 'isUpdateCap')
 	isUpdateCap
 		.withArgs(
 			{ network: 'mainnet' } as any,
-			BigNumber.from(100),
+			bignumber(dummyNumber),
 			'dummy-transaction'
 		)
 		.resolves(true)
 	isUpdateCap
 		.withArgs(
 			{ network: 'mainnet' } as any,
-			BigNumber.from(100),
+			bignumber(dummyNumber),
 			'dummy-transaction2'
 		)
 		.resolves(false)
@@ -50,7 +55,7 @@ test('Returns oraclize data', async (t) => {
 		network: 'mainnet',
 		signatureOptions: null as any,
 	})
-	t.is(res!.message, '100')
+	t.is(res!.message, '3175573141986827732')
 	t.is(res!.status, 0)
 	t.is(res!.statusMessage, 'mainnet dummy-sig')
 })

--- a/src/oraclize.ts
+++ b/src/oraclize.ts
@@ -7,9 +7,10 @@ export const oraclize: FunctionOraclizer = async ({ query, network }) => {
 	const provider = getProvider(network)
 	const cap = await getCap(provider)
 	const isUpdate = await isUpdateCap(provider, cap, query.transactionhash)
+	const [message] = cap.toFixed().split('.') // Forcibly truncates the decimal point regardless of the BigNumber specifications.
 	const result = isUpdate
 		? {
-				message: cap.toString(),
+				message,
 				status: 0,
 				statusMessage: `${network} ${query.publicSignature}`,
 		  }

--- a/src/original/balance.test.ts
+++ b/src/original/balance.test.ts
@@ -50,13 +50,13 @@ test.before(() => {
 // getDevBalanceOfLiquidityPool
 test('get dev balance.', async (t) => {
 	const balance = await getDevBalanceOfLiquidityPool(null as any)
-	t.true(balance.eq(BigNumber.from(100)))
+	t.true(balance.eq(100))
 })
 
 // getWEthBalanceOfLiquidityPool
 test('get weth balance.', async (t) => {
 	const balance = await getWEthBalanceOfLiquidityPool(null as any)
-	t.true(balance.eq(BigNumber.from(100)))
+	t.true(balance.eq(100))
 })
 
 test.after(() => {

--- a/src/original/balance.ts
+++ b/src/original/balance.ts
@@ -1,4 +1,5 @@
 import { providers, BigNumber } from 'ethers'
+import { bignumber, BigNumber as MathBigNumber } from 'mathjs'
 import { getErc20Instance, getAddressConfigInstance } from '../common'
 
 const UNISWAP_LP = '0x4168CEF0fCa0774176632d86bA26553E3B9cF59d'
@@ -6,18 +7,18 @@ const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
 
 export const getDevBalanceOfLiquidityPool = async (
 	provider: providers.BaseProvider
-): Promise<BigNumber> => {
+): Promise<MathBigNumber> => {
 	const addressConfigInstance = getAddressConfigInstance(provider)
 	const devTokenAddress: string = await addressConfigInstance.token()
 	const devInstance = getErc20Instance(devTokenAddress, provider)
 	const balance: BigNumber = await devInstance.balanceOf(UNISWAP_LP)
-	return balance
+	return bignumber(balance.toString())
 }
 
 export const getWEthBalanceOfLiquidityPool = async (
 	provider: providers.BaseProvider
-): Promise<BigNumber> => {
+): Promise<MathBigNumber> => {
 	const wEthInstance = getErc20Instance(WETH, provider)
 	const balance: BigNumber = await wEthInstance.balanceOf(UNISWAP_LP)
-	return balance
+	return bignumber(balance.toString())
 }

--- a/src/original/calculate.test.ts
+++ b/src/original/calculate.test.ts
@@ -12,7 +12,10 @@ test('calculate geometric mean', async (t) => {
 		'0xhugahuga',
 		'0xkayokayo',
 	])
-	t.is(res.toString(), '18171205928321303453986')
+	t.is(
+		res.toFixed(),
+		'18171205928321396588912.11756327260502428210463141219671481334289'
+	)
 })
 
 test('calculate geometric mean(If not staked, convert to 1000000000000000000)', async (t) => {
@@ -28,7 +31,10 @@ test('calculate geometric mean(If not staked, convert to 1000000000000000000)', 
 		'0xqwerqwer',
 		'0xpowefwev',
 	])
-	t.is(res.toString(), '359443181873802315917')
+	t.is(
+		res.toFixed(),
+		'359443181873802315917.2467881553402793655164293568395597722664181'
+	)
 })
 
 test('if there is no value, result is 0(calculateGeometricMean)', async (t) => {

--- a/src/original/calculate.ts
+++ b/src/original/calculate.ts
@@ -1,5 +1,4 @@
-import { BigNumber } from 'ethers'
-import { pow, bignumber, divide } from 'mathjs'
+import { pow, bignumber, BigNumber } from 'mathjs'
 
 export const calculateGeometricMean = (
 	valueMap: ReadonlyMap<string, string>,
@@ -8,10 +7,10 @@ export const calculateGeometricMean = (
 	const values = authinticatedProperties.map((property) => {
 		const value = valueMap.get(property)
 		const tmp = typeof value === 'undefined' ? '1000000000000000000' : value
-		return BigNumber.from(tmp)
+		return bignumber(tmp)
 	})
 	return values.length === 0
-		? BigNumber.from(0)
+		? bignumber(0)
 		: innerCalculateGeometricMean(values)
 }
 
@@ -21,12 +20,9 @@ const innerCalculateGeometricMean = (
 	const result = values.reduce((data1, data2) => {
 		return data1.mul(data2)
 	})
-	const tmp = divide(1, values.length)
-	const calculationResults = pow(
-		bignumber(result.toString()),
-		bignumber(tmp.toString())
-	)
-	return BigNumber.from(bignumber(calculationResults.toString()).toFixed(0))
+	const tmp = bignumber(1).div(values.length)
+	const calculationResults = pow(result, tmp)
+	return bignumber(calculationResults.toString())
 }
 
 export const calculateArithmeticMean = (
@@ -36,13 +32,11 @@ export const calculateArithmeticMean = (
 	const values = authinticatedProperties.map((property) => {
 		const value = valueMap.get(property)
 		const tmp = typeof value === 'undefined' ? '0' : value
-		return BigNumber.from(tmp)
+		return bignumber(tmp)
 	})
 
 	const result =
-		values.length === 0
-			? BigNumber.from(0)
-			: innerCalculateArithmeticMean(values)
+		values.length === 0 ? bignumber(0) : innerCalculateArithmeticMean(values)
 	return result
 }
 

--- a/src/original/cap.test.ts
+++ b/src/original/cap.test.ts
@@ -2,7 +2,8 @@
 /* eslint-disable functional/prefer-readonly-type */
 import test from 'ava'
 import sinon from 'sinon'
-import { providers, BigNumber } from 'ethers'
+import { providers } from 'ethers'
+import { bignumber, BigNumber } from 'mathjs'
 import { getCap } from './cap'
 import * as balanceModules from './balance'
 import * as graphqlModules from './graphql'
@@ -36,7 +37,7 @@ test.before(() => {
 	)
 	getDevBalanceOfLiquidityPool
 		.withArgs(null as any)
-		.resolves(BigNumber.from('20000000000000000000000'))
+		.resolves(bignumber('20000000000000000000000'))
 
 	getWEthBalanceOfLiquidityPool = sinon.stub(
 		balanceModules,
@@ -44,7 +45,7 @@ test.before(() => {
 	)
 	getWEthBalanceOfLiquidityPool
 		.withArgs(null as any)
-		.resolves(BigNumber.from('100000000000000000000'))
+		.resolves(bignumber('100000000000000000000'))
 
 	getAuthinticatedProperty = sinon.stub(
 		graphqlModules,
@@ -70,7 +71,10 @@ test.before(() => {
 
 test('get withdraw cap', async (t) => {
 	const res = await getCap(null as any)
-	t.is(res.toString(), '7188863637476046318340')
+	t.is(
+		res.toFixed(),
+		'7152919319288666086753.21108429127155937377694420110723946810172'
+	)
 })
 
 test.after(() => {

--- a/src/original/cap.ts
+++ b/src/original/cap.ts
@@ -1,4 +1,4 @@
-import { providers, BigNumber } from 'ethers'
+import { providers } from 'ethers'
 import {
 	getDevBalanceOfLiquidityPool,
 	getWEthBalanceOfLiquidityPool,
@@ -6,6 +6,7 @@ import {
 import { getLockupSumValues, getAuthinticatedProperty } from './graphql'
 import { getAuthinticatedPropertyList, getLockupValuesMap } from './format'
 import { calculateGeometricMean, calculateArithmeticMean } from './calculate'
+import { bignumber, BigNumber } from 'mathjs'
 
 export const getCap = async (
 	provider: providers.BaseProvider
@@ -26,6 +27,10 @@ export const getCap = async (
 		lockupValuesMap,
 		authinticatedPropertyList
 	)
-	const tmp = BigNumber.from(1).sub(wEthBalance.div(devBalance))
-	return devBalance.mul(tmp).mul(12).mul(geometricMean).div(arithmeticMean)
+	const tmp = bignumber(1).sub(wEthBalance.div(devBalance))
+	return devBalance
+		.times(tmp)
+		.times(12)
+		.times(geometricMean)
+		.div(arithmeticMean)
 }

--- a/src/original/check/check-details.test.ts
+++ b/src/original/check/check-details.test.ts
@@ -1,21 +1,21 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import test from 'ava'
-import { BigNumber } from 'ethers'
 import { isSameVal, isLatestLockedupEvent } from './check-details'
+import { bignumber, BigNumber } from 'mathjs'
 
 test('If the values are the same, true will be returned.', async (t) => {
 	const capFunc = async (): Promise<BigNumber> => {
-		return BigNumber.from(100)
+		return bignumber(100)
 	}
-	const res = await isSameVal({ cap: capFunc } as any, BigNumber.from(100))
+	const res = await isSameVal({ cap: capFunc } as any, bignumber(100))
 	t.true(res)
 })
 
 test('If the value is different, false will be returned.', async (t) => {
 	const capFunc = async (): Promise<BigNumber> => {
-		return BigNumber.from(200)
+		return bignumber(200)
 	}
-	const res = await isSameVal({ cap: capFunc } as any, BigNumber.from(100))
+	const res = await isSameVal({ cap: capFunc } as any, bignumber(100))
 	t.false(res)
 })
 

--- a/src/original/check/check-details.ts
+++ b/src/original/check/check-details.ts
@@ -1,11 +1,12 @@
-import { ethers, providers, BigNumber } from 'ethers'
+import { ethers, providers } from 'ethers'
+import { bignumber, BigNumber } from 'mathjs'
 
 export const isSameVal = async (
 	lockup: ethers.Contract,
 	nextCap: BigNumber
 ): Promise<boolean> => {
 	const cap: BigNumber = await lockup.cap()
-	return BigNumber.from(cap).eq(nextCap)
+	return bignumber(cap).eq(nextCap)
 }
 
 export const isLatestLockedupEvent = async (

--- a/src/original/check/check.test.ts
+++ b/src/original/check/check.test.ts
@@ -2,7 +2,8 @@
 /* eslint-disable functional/prefer-readonly-type */
 
 import test from 'ava'
-import { BigNumber, Contract } from 'ethers'
+import { Contract } from 'ethers'
+import { bignumber, BigNumber } from 'mathjs'
 import sinon from 'sinon'
 import { isUpdateCap } from './check'
 import * as checkDetailsModules from './check-details'
@@ -33,38 +34,38 @@ test.before(() => {
 })
 
 test('If it is the last event and the current value is the same.', async (t) => {
-	isSameVal.withArgs(null as any, BigNumber.from(100)).resolves(true)
+	isSameVal.withArgs(null as any, bignumber(100)).resolves(true)
 	isLatestLockedupEvent
 		.withArgs(null as any, null as any, 'dummy-hash')
 		.resolves(true)
-	const res = await isUpdateCap(null as any, BigNumber.from(100), 'dummy-hash')
+	const res = await isUpdateCap(null as any, bignumber(100), 'dummy-hash')
 	t.false(res)
 })
 
 test('If it is not the last event and the current value is the same.', async (t) => {
-	isSameVal.withArgs(null as any, BigNumber.from(300)).resolves(true)
+	isSameVal.withArgs(null as any, bignumber(300)).resolves(true)
 	isLatestLockedupEvent
 		.withArgs(null as any, null as any, 'dummy-hash2')
 		.resolves(false)
-	const res = await isUpdateCap(null as any, BigNumber.from(300), 'dummy-hash2')
+	const res = await isUpdateCap(null as any, bignumber(300), 'dummy-hash2')
 	t.false(res)
 })
 
 test('If it is the last event and the current value is different', async (t) => {
-	isSameVal.withArgs(null as any, BigNumber.from(200)).resolves(false)
+	isSameVal.withArgs(null as any, bignumber(200)).resolves(false)
 	isLatestLockedupEvent
 		.withArgs(null as any, null as any, 'dummy-hash3')
 		.resolves(true)
-	const res = await isUpdateCap(null as any, BigNumber.from(200), 'dummy-hash3')
+	const res = await isUpdateCap(null as any, bignumber(200), 'dummy-hash3')
 	t.true(res)
 })
 
 test('If it is not the last event and the current value is different', async (t) => {
-	isSameVal.withArgs(null as any, BigNumber.from(400)).resolves(false)
+	isSameVal.withArgs(null as any, bignumber(400)).resolves(false)
 	isLatestLockedupEvent
 		.withArgs(null as any, null as any, 'dummy-hash4')
 		.resolves(false)
-	const res = await isUpdateCap(null as any, BigNumber.from(400), 'dummy-hash4')
+	const res = await isUpdateCap(null as any, bignumber(400), 'dummy-hash4')
 	t.false(res)
 })
 

--- a/src/original/check/check.ts
+++ b/src/original/check/check.ts
@@ -1,4 +1,5 @@
-import { providers, BigNumber } from 'ethers'
+import { providers } from 'ethers'
+import { BigNumber } from 'mathjs'
 import { getLockupInstance } from '../../common'
 import { isSameVal, isLatestLockedupEvent } from './check-details'
 


### PR DESCRIPTION
Patches #1 

`BigNumber` created by `ethers.BigNumber.from` ignores decimal point because emulate the behavior of numbers in EVM. Therefore, replace it with `mathjs.bignumber` for accurate calculations.

The following formula matches the formula expected in [this test case](https://github.com/dev-protocol/khaos-update-cap/blob/df040b5bd40feeb6ee03c6e29ddcb0fc9a49632f/src/original/cap.test.ts#L72-L78). And the test proves it is correct. Therefore, it means that the change by this pull request is correct.
Calculated `20000000000000000000000*(1-(100000000000000000000/20000000000000000000000))*12*((10000000000000000000000*20000000000000000000000*30000000000000000000000*1000000000000000000*1000000000000000000)^(1/5))/(60000000000000000000000/5)` with https://keisan.casio.com/calculator = `7152919319288666086753.2110842912715593737769442011`